### PR TITLE
Streamline Google Traffic tiles

### DIFF
--- a/Osmand_online_maps/Metainfo/Maps_full_en/=Overlay=Road=Google_Traffic/.metainfo
+++ b/Osmand_online_maps/Metainfo/Maps_full_en/=Overlay=Road=Google_Traffic/.metainfo
@@ -1,9 +1,9 @@
 [url_template]
-http://mt{rnd}.google.com/vt?hl=ru&lyrs=m@159000000,traffic|seconds_into_week:-1&style=15&x={1}&y={2}&z={0}&scale=2
+http://mt{rnd}.google.com/vt?lyrs=transit,traffic&style=15&x={1}&y={2}&z={0}&scale=2
 [randoms]
 0,1,2,3
 [min_zoom]
-0
+5
 [max_zoom]
 20
 [ellipsoid]
@@ -15,7 +15,7 @@ false
 [img_density]
 16
 [avg_img_size]
-32000
+8000
 [ext]
 .png
 [expiration_time_minutes]


### PR DESCRIPTION
This change removes the text and POI icons. Although "transit" is part of the request, it doesn't have any visible impact (from my spot-checks). The reduced "avg_img_size" is simply a guess; I don't know what method is used to calculate it, but it's definitely much smaller than before.

I stayed with the existing `style=15`, but there are numerous other style values that might be preferable. I wasn't able to get tiles to appear at zoom levels 4 or below via OsmAnd so I changed min_zoom.